### PR TITLE
feat: update docker to v3.12.0

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.7.7
-appVersion: 3.11.6
+version: 0.8.0
+appVersion: 3.12.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png
 sources:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: verdaccio/verdaccio
-  tag: 3.11.6
+  tag: 3.12.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
This is the last release of v3, actually 3.11.6 is insecure and should not be used anymore.

https://github.com/verdaccio/verdaccio/releases/tag/v3.12.0