### PR TITLE
Adding service-account as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ and their default values.
 | `service.port`                     | Service port to expose                                          | `4873`                |
 | `service.nodePort`                 | Service port to expose                                          | none                  |
 | `service.type`                     | Type of service to create                                       | `ClusterIP`           |
+| `serviceAccount.enabled`           | Enable service account                                          | `false`               |
+| `serviceAccount.name`              | Service account Name                                            | none                  |
+| `extraEnvVars`                     | Define environment variables to be passed to the container      | `{}`                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.8.0
+version: 0.8.1
 appVersion: 3.12.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/deployment.yaml
+++ b/charts/verdaccio/templates/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "verdaccio.fullname" . }}
 spec:
+  {{- if .Values.serviceAccount.enabled }}
+  serviceAccountName: {{ template ".Values.serviceAccount.name" . }}
+  {{- end}}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/charts/verdaccio/templates/service-account.yaml
+++ b/charts/verdaccio/templates/service-account.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template ".Values.serviceAccount.name" . }}
+  labels:
+    app: {{ template "verdaccio.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -48,6 +48,11 @@ ingress:
 #     hosts:
 #       - npm.blah.com
 
+## Service account
+serviceAccount:
+  enabled: false
+  # name:
+
 configMap: |
   # This is the config file used for the docker images.
   # It allows all users to do anything, so don't use it on production systems.


### PR DESCRIPTION
migration of: https://github.com/helm/charts/pull/21664

#### What this PR does / why we need it:

Adding serviceAccount as an option, because I am trying to use secrets via vault and without serviceAccount it was impossible

#### Which issue this PR fixes

I need to place uplinks with auth-property in the settings of verdaccio and this secret is protected by vault (DOC:  https://verdaccio.org/docs/en/uplinks#auth-property)
