### PR TITLE
Add extraEnvVars setting

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.10.0
+version: 0.11.0
 appVersion: 3.13.1
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/deployment.yaml
+++ b/charts/verdaccio/templates/deployment.yaml
@@ -63,6 +63,10 @@ spec:
             - mountPath: /verdaccio/conf
               name: config
               readOnly: true
+          env:
+{{- if .Values.extraEnvVars }}
+{{ toYaml .Values.extraEnvVars | indent 12 }}
+{{- end }}
       {{- if .Values.securityContext.enabled }}
       # Allow non-root user to access PersistentVolume
       securityContext:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -53,6 +53,16 @@ serviceAccount:
   enabled: false
   # name:
 
+# Extra Environment Values - allows yaml definitions
+extraEnvVars:
+#  - name: VALUE_FROM_SECRET
+#    valueFrom:
+#      secretKeyRef:
+#        name: secret_name
+#        key: secret_key
+#  - name: REGULAR_VAR
+#    value: ABC
+
 configMap: |
   # This is the config file used for the docker images.
   # It allows all users to do anything, so don't use it on production systems.


### PR DESCRIPTION
Re-add the feature from https://github.com/helm/charts/pull/20223

For some reason it's included in the README, but appears it got lost somewhere.