### PR TITLE
Updated the default image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ helm install --name npm verdaccio/verdaccio
 ### Deploy a specific version
 
 ```bash
-helm install --name npm --set image.tag=3.13.1 verdaccio/verdaccio
+helm install --name npm --set image.tag=4.6.2 verdaccio/verdaccio
 ```
 
 ### Upgrading Verdaccio
@@ -77,7 +77,7 @@ and their default values.
 | `existingConfigMap`                | Name of custom ConfigMap to use                                 | `false`               |
 | `image.pullPolicy`                 | Image pull policy                                               | `IfNotPresent`        |
 | `image.repository`                 | Verdaccio container image repository                            | `verdaccio/verdaccio` |
-| `image.tag`                        | Verdaccio container image tag                                   | `3.11.6`              |
+| `image.tag`                        | Verdaccio container image tag                                   | `4.6.2`               |
 | `nodeSelector`                     | Node labels for pod assignment                                  | `{}`                  |
 | `tolerations`                      | List of node taints to tolerate                                 | `[]`                  |
 | `persistence.accessMode`           | PVC Access Mode for Verdaccio volume                            | `ReadWriteOnce`       |

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.12.0
-appVersion: 3.13.1
+version: 0.13.0
+appVersion: 4.6.2
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png
 sources:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: verdaccio/verdaccio
-  tag: 3.12.0
+  tag: 4.6.2
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Updated the version of the default image for the chart to the most recent.

I did the tests and it seems to be very compatible with previous versions, I had no impact, in my case I migrated a chart that was using `3.12.0` to `4.6.2` and everything continued to work perfectly.

I think it is worth keeping the default image on the chart always the most recent, so new people who are going to use the chart will already test the current version.