### PR TITLE
Update Ingress Template

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.13.0
+version: 0.14.0
 appVersion: 4.6.2
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/ingress.yaml
+++ b/charts/verdaccio/templates/ingress.yaml
@@ -1,7 +1,12 @@
 {{- if .Values.ingress.enabled }}
 {{- $serviceName := include "verdaccio.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
+{{- $paths := .Values.ingress.paths -}}
+{{- if .Values.ingress.v1beta1 }}
 apiVersion: extensions/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "verdaccio.fullname" . }}
@@ -20,12 +25,8 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
-            backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-          {{- if (not .Values.ingress.disableSecondPath) }}
-          - path: /*
+          {{- range $p := $paths }}
+          - path: {{ $p }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/charts/verdaccio/templates/ingress.yaml
+++ b/charts/verdaccio/templates/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- if .Values.ingress.hosts }}
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}
       http:
@@ -31,6 +32,16 @@ spec:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
           {{- end -}}
+    {{- end -}}
+    {{- else }}
+    - http:
+        paths:
+    {{- range $p := $paths }}
+          - path: {{ $p }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/verdaccio/templates/ingress.yaml
+++ b/charts/verdaccio/templates/ingress.yaml
@@ -24,10 +24,12 @@ spec:
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+          {{- if (not .Values.ingress.disableSecondPath) }}
           - path: /*
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+          {{- end -}}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/verdaccio/templates/ingress.yaml
+++ b/charts/verdaccio/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "verdaccio.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $paths := .Values.ingress.paths -}}
-{{- if .Values.ingress.v1beta1 }}
+{{- if .Values.ingress.useExtensionsApi }}
 apiVersion: extensions/v1beta1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -39,6 +39,8 @@ resources: {}
 
 ingress:
   enabled: false
+  # If your Ingress controller can not parse a / and a /* path, set this to true
+  disableSecondPath: false
 # hosts:
 #   - npm.blah.com
 # annotations:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -41,10 +41,10 @@ ingress:
   enabled: false
   # Set to true if you are on an old cluster where apiVersion extensions/v1beta1 is required
   v1beta1: false
+  paths:
+    - /
 # hosts:
 #   - npm.blah.com
-# paths:
-#   - "/"
 # annotations:
 #   kubernetes.io/ingress.class: nginx
 # tls:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -39,12 +39,12 @@ resources: {}
 
 ingress:
   enabled: false
-  # If your Ingress controller can not parse a / and a /* path, set this to true
-  disableSecondPath: false
   # Set to true if you are on an old cluster where apiVersion extensions/v1beta1 is required
   v1beta1: false
 # hosts:
 #   - npm.blah.com
+# paths:
+#   - "/"
 # annotations:
 #   kubernetes.io/ingress.class: nginx
 # tls:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -40,7 +40,7 @@ resources: {}
 ingress:
   enabled: false
   # Set to true if you are on an old cluster where apiVersion extensions/v1beta1 is required
-  v1beta1: false
+  useExtensionsApi: false
   paths:
     - /
 # hosts:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -41,6 +41,8 @@ ingress:
   enabled: false
   # If your Ingress controller can not parse a / and a /* path, set this to true
   disableSecondPath: false
+  # Set to true if you are on an old cluster where apiVersion extensions/v1beta1 is required
+  v1beta1: false
 # hosts:
 #   - npm.blah.com
 # annotations:


### PR DESCRIPTION
I present this as a suggestion, and it will:

- Update the ingress to remove the second path that conflicts in Traefik 2.x and I assume other ingress controllers that are more strict about their matching.
- Update the deprecated apiVersion for this K8s object and leave an option for backwards compatibility for those that are on older kubernetes versions.

I am running this in production currently and it seems to work with the second ingress path disabled and the new api version.  I have added comments to the values file for posterity.

Would you like anything changed on this?