### PR TITLE
fix: service account and allow setting annotations

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.15.0
+version: 0.15.1
 appVersion: 4.6.2
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/_helpers.tpl
+++ b/charts/verdaccio/templates/_helpers.tpl
@@ -14,3 +14,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "verdaccio.serviceAccountName" -}}
+{{- if .Values.serviceAccount.enabled }}
+{{- default (include "verdaccio.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/verdaccio/templates/deployment.yaml
+++ b/charts/verdaccio/templates/deployment.yaml
@@ -8,9 +8,6 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "verdaccio.fullname" . }}
 spec:
-  {{- if .Values.serviceAccount.enabled }}
-  serviceAccountName: {{ template ".Values.serviceAccount.name" . }}
-  {{- end}}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -34,6 +31,9 @@ spec:
         app: {{ template "verdaccio.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ include "verdaccio.serviceAccountName" . }}
+      {{- end}}
       containers:
         - name: {{ template "verdaccio.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/verdaccio/templates/service-account.yaml
+++ b/charts/verdaccio/templates/service-account.yaml
@@ -1,12 +1,16 @@
-{{- if .Values.serviceAccount.enabled }}
+{{- if .Values.serviceAccount.enabled -}}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template ".Values.serviceAccount.name" . }}
+  name: {{ include "verdaccio.serviceAccountName" . }}
   labels:
     app: {{ template "verdaccio.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -54,8 +54,13 @@ ingress:
 
 ## Service account
 serviceAccount:
+  # Specifies whether a service account should be created
   enabled: false
-  # name:
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
 
 # Extra Environment Values - allows yaml definitions
 extraEnvVars:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -59,7 +59,7 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If not set and enabled is true, a name is generated using the Chart's fullname template
   name: ""
 
 # Extra Environment Values - allows yaml definitions


### PR DESCRIPTION
This PR fixes assignment of a ServiceAccount to the Deployment + adds the option to provide ServiceAccount annotations (eg for using with EKS IRSA).