### PR TITLE
Fix UID of deployment to match dockerfile

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.14.0
+version: 0.15.0
 appVersion: 4.6.2
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -159,7 +159,7 @@ persistence:
 
 securityContext:
   enabled: true
-  runAsUser: 100
+  runAsUser: 10001
   fsGroup: 101
 
 priorityClass:


### PR DESCRIPTION
The dockerfile has a user for 10001, and the security context was using the wrong one.  So migrating files from the old deployment I had was still stuck with the 10001 uid and lots of things were broken.  This fixes that.