### PR TITLE
Remove name flag from `helm install` command for helm v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ deployment on a [Kubernetes](https://kubernetes.io) cluster using the
 helm repo add verdaccio https://charts.verdaccio.org
 ```
 
-In this example we use `npm` as release name:
+### Install Verdaccio chart
+
+In this example we use `npm` as release name.
+
+For **Helm v3**:
 
 ```bash
 helm install npm verdaccio/verdaccio

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ can be provided while installing the chart. For example,
 $ helm install npm -f values.yaml verdaccio/verdaccio
 ```
 
-> **Tip**: You can use the default [values.yaml](values.yaml)
+> **Tip**: You can use the default [values.yaml](charts/verdaccio/values.yaml)
 
 ### Custom ConfigMap
 

--- a/README.md
+++ b/README.md
@@ -34,24 +34,24 @@ helm repo add verdaccio https://charts.verdaccio.org
 
 ### Install Verdaccio chart
 
-In this example we use `npm` as release name.
-
-For **Helm v3**:
+In this example we use `npm` as release name:
 
 ```bash
+# Helm v3+
 helm install npm verdaccio/verdaccio
-```
 
-If you are using **Helm v2 or older version**, you should use `name` flag to assign release name:
-
-```bash
+# Helm v2 or older
 helm install --name npm verdaccio/verdaccio
 ```
 
 ### Deploy a specific version
 
 ```bash
+# Helm v3+
 helm install npm --set image.tag=4.6.2 verdaccio/verdaccio
+
+# Helm v2 or older
+helm install --name npm --set image.tag=4.6.2 verdaccio/verdaccio
 ```
 
 ### Upgrading Verdaccio
@@ -117,8 +117,14 @@ and their default values.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
-```
+```bash
+# Helm v3+
 $ helm install my-release \
+  --set service.type=LoadBalancer \
+    verdaccio/verdaccio
+
+# Helm v2 or older
+$ helm install --name my-release \
   --set service.type=LoadBalancer \
     verdaccio/verdaccio
 ```
@@ -128,8 +134,12 @@ The above command sets the service type LoadBalancer.
 Alternatively, a YAML file that specifies the values for the above parameters
 can be provided while installing the chart. For example,
 
-```
+```bash
+# Helm v3+
 $ helm install npm -f values.yaml verdaccio/verdaccio
+
+# Helm v2 or older
+$ helm install --name npm -f values.yaml verdaccio/verdaccio
 ```
 
 > **Tip**: You can use the default [values.yaml](charts/verdaccio/values.yaml)
@@ -160,7 +170,13 @@ It is possible to mount several volumes using `Persistence.volumes` and
 1. Install the chart
 
 ```bash
+# Helm v3+
 $ helm install npm \
+    --set persistence.existingClaim=PVC_NAME \
+    verdaccio/verdaccio
+
+# Helm v2 or older
+$ helm install --name npm \
     --set persistence.existingClaim=PVC_NAME \
     verdaccio/verdaccio
 ```

--- a/README.md
+++ b/README.md
@@ -35,13 +35,19 @@ helm repo add verdaccio https://charts.verdaccio.org
 In this example we use `npm` as release name:
 
 ```bash
+helm install npm verdaccio/verdaccio
+```
+
+If you are using **Helm v2 or older version**, you should use `name` flag to assign release name:
+
+```bash
 helm install --name npm verdaccio/verdaccio
 ```
 
 ### Deploy a specific version
 
 ```bash
-helm install --name npm --set image.tag=4.6.2 verdaccio/verdaccio
+helm install npm --set image.tag=4.6.2 verdaccio/verdaccio
 ```
 
 ### Upgrading Verdaccio
@@ -108,7 +114,7 @@ and their default values.
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```
-$ helm install --name my-release \
+$ helm install my-release \
   --set service.type=LoadBalancer \
     verdaccio/verdaccio
 ```
@@ -119,10 +125,10 @@ Alternatively, a YAML file that specifies the values for the above parameters
 can be provided while installing the chart. For example,
 
 ```
-$ helm install --name npm -f values.yaml verdaccio/verdaccio
+$ helm install npm -f values.yaml verdaccio/verdaccio
 ```
 
-> **Tip**: You can use the default [values.yaml](charts/verdaccio/values.yaml)
+> **Tip**: You can use the default [values.yaml](values.yaml)
 
 ### Custom ConfigMap
 
@@ -150,7 +156,7 @@ It is possible to mount several volumes using `Persistence.volumes` and
 1. Install the chart
 
 ```bash
-$ helm install --name npm \
+$ helm install npm \
     --set persistence.existingClaim=PVC_NAME \
     verdaccio/verdaccio
 ```


### PR DESCRIPTION
Current Helm(v3) is no longer support `--name` flag, the release name is now mandatory as part of the command. So if you using the `helm install` command in README, you'll get an error like `Error: unknown flag: --name`.

So I edited some examples in README.md

Related links:
* [kubernetes - Helm install unknown flag --name - Stack Overflow](https://stackoverflow.com/questions/57961162/helm-install-unknown-flag-name)
* [Helm | Helm Install](https://helm.sh/docs/helm/helm_install/)