### PR TITLE
Add support for AWS LoadBalancer Controller with actions annotation

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.16.2
+version: 0.16.3
 appVersion: 4.7.2
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/ingress.yaml
+++ b/charts/verdaccio/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $serviceName := include "verdaccio.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $paths := .Values.ingress.paths -}}
+{{- $ingressExtraPaths := .Values.ingress.extraPaths -}}
 {{- if .Values.ingress.useExtensionsApi }}
 apiVersion: extensions/v1beta1
 {{- else }}
@@ -26,6 +27,12 @@ spec:
     - host: {{ $host }}
       http:
         paths:
+          {{- range $ingressExtraPaths }}
+          - path: {{ default "/" .path | quote }}
+            backend:
+              serviceName: {{ default $serviceName .service }}
+              servicePort: {{ default $servicePort .port }}
+          {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
             backend:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -53,6 +53,7 @@ ingress:
 # annotations:
 #   kubernetes.io/ingress.class: nginx
 # tls:
+
 #   - secretName: secret
 #     hosts:
 #       - npm.blah.com

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -53,10 +53,10 @@ ingress:
 # annotations:
 #   kubernetes.io/ingress.class: nginx
 # tls:
-
 #   - secretName: secret
 #     hosts:
 #       - npm.blah.com
+
 ## Service account
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -45,6 +45,9 @@ ingress:
   useExtensionsApi: false
   paths:
     - /
+  # Use this to define, ALB ingress's actions annotation based routing. Ex: for ssl-redirect
+  # Ref: https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/tasks/ssl_redirect/
+  extraPaths: []
 # hosts:
 #   - npm.blah.com
 # annotations:
@@ -53,7 +56,6 @@ ingress:
 #   - secretName: secret
 #     hosts:
 #       - npm.blah.com
-
 ## Service account
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Closes https://github.com/verdaccio/charts/issues/39. 

Added new variable `.Values.ingress.extraPaths`. This enables  to have path with custom `serviceName` and `servicePort`. 
Something like this can be defined in ingress

```yaml
  extraPaths:
    - service: ssl-redirect
      port: use-annotation
      path: /*
```