### PR TITLE
feat: enable keep alive by default

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.16.4
+version: 0.17.0
 appVersion: 4.7.2
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -109,6 +109,10 @@ configMap: |
   uplinks:
     npmjs:
       url: https://registry.npmjs.org/
+      agent_options:
+        keepAlive: true
+        maxSockets: 40
+        maxFreeSockets: 10
 
   packages:
     '@*/*':


### PR DESCRIPTION
Improves considerably the performance of verdaccio using keepAlive  by default

follow up of https://github.com/verdaccio/verdaccio/pull/2014