### PR TITLE
chore: add linting step

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,47 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.1
+
+      # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
+      # yamllint (https://github.com/adrienverge/yamllint) which require Python
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+        with:
+          version: v3.3.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.1.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ct.yaml=

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -44,4 +44,4 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --config ct.yaml=
+        run: ct install --config ct.yaml

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -14,5 +14,5 @@ keywords:
 maintainers:
   - name: juanpicado
     email: juanpicado19@gmail.com
-  - name: Jhon Mike
+  - name: jhonmike
     email: jhon.msdev@gmail.com

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,18 +1,18 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.16.3
+version: 0.16.4
 appVersion: 4.7.2
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png
 sources:
-- https://verdaccio.org
-- https://github.com/verdaccio/verdaccio
+  - https://verdaccio.org
+  - https://github.com/verdaccio/verdaccio
 keywords:
-- npm
-- nodejs
+  - npm
+  - nodejs
 maintainers:
-- name: juanpicado
-  email: juanpicado19@gmail.com
-- name: Jhon Mike
-  email: jhon.msdev@gmail.com
+  - name: juanpicado
+    email: juanpicado19@gmail.com
+  - name: Jhon Mike
+    email: jhon.msdev@gmail.com

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -31,7 +31,8 @@ tolerations: []
 podAnnotations: {}
 replicaCount: 1
 
-resources: {}
+resources:
+  {}
   # limits:
   #  cpu: 100m
   #  memory: 512Mi
@@ -78,7 +79,7 @@ extraEnvVars:
 #    value: ABC
 
 configMap: |
-  # This is the config file used for the docker images.
+  # This is the config file used for the docker images. (example)
   # It allows all users to do anything, so don't use it on production systems.
   #
   # Do not configure host and port under `listen` in this file
@@ -160,8 +161,8 @@ persistence:
   accessMode: ReadWriteOnce
   size: 8Gi
   volumes:
-#  - name: nothing
-#    emptyDir: {}
+  #  - name: nothing
+  #    emptyDir: {}
   mounts:
 #  - mountPath: /var/nothing
 #    name: nothing

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -79,7 +79,7 @@ extraEnvVars:
 #    value: ABC
 
 configMap: |
-  # This is the config file used for the docker images. (example)
+  # This is the config file used for the docker images.
   # It allows all users to do anything, so don't use it on production systems.
   #
   # Do not configure host and port under `listen` in this file

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,7 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+chart-dirs:
+  - charts
+chart-repos:
+  - verdaccio=https://charts.verdaccio.org
+helm-extra-args: --timeout 600s

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,5 +3,5 @@ remote: origin
 chart-dirs:
   - charts
 chart-repos:
-  - verdaccio=https://charts.verdaccio.org
+  - verdaccio=https://charts.verdaccio.org/index.yaml
 helm-extra-args: --timeout 600s

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,5 +3,5 @@ remote: origin
 chart-dirs:
   - charts
 chart-repos:
-  - verdaccio=https://charts.verdaccio.org/index.yaml
+  - verdaccio=https://charts.verdaccio.org
 helm-extra-args: --timeout 600s


### PR DESCRIPTION
This PR inlcudes the following GutHub actions for lining the chart:

Here the official example:
https://github.com/helm/charts-repo-actions-demo
https://github.com/helm/chart-testing-action
https://github.com/helm/kind-action

What does it lint?

* correct bump up (verify against the latest changes in chart repository)
* validate yaml
* trigger a local kubernetes to install the chart
