### PR TITLE
feat!: chart as apiVersion 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ $ helm install verdaccio/verdaccio
 
 > ⚠️ If you are using **stable/verdaccio** chart, [be aware is deprecated](https://github.com/helm/charts/pull/21929), forward all new PR and or issues to this repository.
 
+> If you need support for Helm v2, please use `<=v0.19.0`, be aware we do not support Helm v2 anymore.
+
 ## Introduction
 
 This chart bootstraps a [Verdaccio](https://github.com/verdaccio/verdaccio)
@@ -39,9 +41,6 @@ In this example we use `npm` as release name:
 ```bash
 # Helm v3+
 helm install npm verdaccio/verdaccio
-
-# Helm v2 or older
-helm install --name npm verdaccio/verdaccio
 ```
 
 ### Deploy a specific version
@@ -49,9 +48,6 @@ helm install --name npm verdaccio/verdaccio
 ```bash
 # Helm v3+
 helm install npm --set image.tag=4.6.2 verdaccio/verdaccio
-
-# Helm v2 or older
-helm install --name npm --set image.tag=4.6.2 verdaccio/verdaccio
 ```
 
 ### Upgrading Verdaccio
@@ -73,9 +69,6 @@ To uninstall/delete the `npm` deployment:
 ```bash
 # Helm v3+
 helm uninstall npm
-
-# Helm v2 or older
-helm delete npm
 ```
 
 The command removes all the Kubernetes components associated with the chart and
@@ -126,11 +119,6 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 $ helm install my-release \
   --set service.type=LoadBalancer \
     verdaccio/verdaccio
-
-# Helm v2 or older
-$ helm install --name my-release \
-  --set service.type=LoadBalancer \
-    verdaccio/verdaccio
 ```
 
 The above command sets the service type LoadBalancer.
@@ -141,9 +129,6 @@ can be provided while installing the chart. For example,
 ```bash
 # Helm v3+
 $ helm install npm -f values.yaml verdaccio/verdaccio
-
-# Helm v2 or older
-$ helm install --name npm -f values.yaml verdaccio/verdaccio
 ```
 
 > **Tip**: You can use the default [values.yaml](charts/verdaccio/values.yaml)
@@ -176,11 +161,6 @@ It is possible to mount several volumes using `Persistence.volumes` and
 ```bash
 # Helm v3+
 $ helm install npm \
-    --set persistence.existingClaim=PVC_NAME \
-    verdaccio/verdaccio
-
-# Helm v2 or older
-$ helm install --name npm \
     --set persistence.existingClaim=PVC_NAME \
     verdaccio/verdaccio
 ```

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.19.0
+version: 1.00.0
 appVersion: 4.10.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 1.00.0
+version: 1.0.0
 appVersion: 4.10.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png


### PR DESCRIPTION
This chart should be based on Helm v3 thus the apiVersion should be `v2`

https://helm.sh/docs/topics/v2_v3_migration/