### PR TITLE
Use create for serviceAccount instead of enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ and their default values.
 | `service.port`                     | Service port to expose                                          | `4873`                         |
 | `service.nodePort`                 | Service port to expose                                          | none                           |
 | `service.type`                     | Type of service to create                                       | `ClusterIP`                    |
-| `serviceAccount.enabled`           | Enable service account                                          | `false`                        |
+| `serviceAccount.create`            | Create service account                                          | `false`                        |
 | `serviceAccount.name`              | Service account Name                                            | none                           |
 | `extraEnvVars`                     | Define environment variables to be passed to the container      | `{}`                           |
 

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 1.2.0
+version: 2.0.0
 appVersion: 4.10.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/_helpers.tpl
+++ b/charts/verdaccio/templates/_helpers.tpl
@@ -19,7 +19,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create the name of the service account to use
 */}}
 {{- define "verdaccio.serviceAccountName" -}}
-{{- if .Values.serviceAccount.enabled }}
+{{- if .Values.serviceAccount.create }}
 {{- default (include "verdaccio.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/charts/verdaccio/templates/deployment.yaml
+++ b/charts/verdaccio/templates/deployment.yaml
@@ -34,9 +34,7 @@ spec:
         {{- include "tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}        
     spec:
-      {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ include "verdaccio.serviceAccountName" . }}
-      {{- end}}
       containers:
         - name: {{ template "verdaccio.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/verdaccio/templates/service-account.yaml
+++ b/charts/verdaccio/templates/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.enabled -}}
+{{- if .Values.serviceAccount.create -}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -71,7 +71,7 @@ ingress:
 ## Service account
 serviceAccount:
   # Specifies whether a service account should be created
-  enabled: false
+  create: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -75,7 +75,7 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
-  # If not set and enabled is true, a name is generated using the Chart's fullname template
+  # If not set and create is true, a name is generated using the Chart's fullname template
   name: ""
 
 # Extra Environment Values - allows yaml definitions


### PR DESCRIPTION
Setting service account name with `serviceAccount.create` is useful with aws-cdk's service account using IRSA

```typescript
  // create service account in cdk kubernetes manifest
  const sa = new eks.ServiceAccount(scope, 'verdaccio-sa', {
    cluster: ...,
    name: 'verdaccio',
  });

...

  new eks.HelmChart(scope, 'verdaccio', {
    ...
    values: {
      serviceAccount: {
        enabled: false,  // do not create service account in helm chart
        name: sa.serviceAccountName,
      }
    }
  }
```