### PR TITLE
zenAptix upstream refactor contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ and their default values.
 | `serviceAccount.create`            | Create service account                                          | `false`                        |
 | `serviceAccount.name`              | Service account Name                                            | none                           |
 | `extraEnvVars`                     | Define environment variables to be passed to the container      | `{}`                           |
+| `extraInitContainers`              | Define additional initContainers to be added to the deployment  | `[]`                           |
+| `securityContext`                  | Define Container Security Context                               | `{runAsUser=10001}`            |
+| `podSecurityContext`               | Define Pod Security Context                                     | `{fsGroup=101}`                |
+| `nameOverride`                     | Set resource name override                                      | `""`                           |
+| `fullnameOverride`                 | Set resource fullname override                                  | `""`                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 2.0.1
+version: 2.1.0
 appVersion: 4.12.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/NOTES.txt
+++ b/charts/verdaccio/templates/NOTES.txt
@@ -3,9 +3,9 @@
 {{- if .Values.ingress.enabled }}
   {{- range $host := .Values.ingress.hosts }}
   {{- if $tls }}
-  https://{{ include "tplvalues.render" (dict "value" $host "context" $) }}
+  https://{{ tpl $host $ }}
   {{- else }}
-  http://{{ include "tplvalues.render" (dict "value" $host "context" $) }}
+  http://{{ tpl $host $ }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/verdaccio/templates/NOTES.txt
+++ b/charts/verdaccio/templates/NOTES.txt
@@ -3,9 +3,9 @@
 {{- if .Values.ingress.enabled }}
   {{- range $host := .Values.ingress.hosts }}
   {{- if $tls }}
-  https://{{ $host }}
+  https://{{ include "tplvalues.render" (dict "value" $host "context" $) }}
   {{- else }}
-  http://{{ $host }}
+  http://{{ include "tplvalues.render" (dict "value" $host "context" $) }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/verdaccio/templates/_helpers.tpl
+++ b/charts/verdaccio/templates/_helpers.tpl
@@ -3,17 +3,54 @@
 Expand the name of the chart.
 */}}
 {{- define "verdaccio.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "verdaccio.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "verdaccio.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "verdaccio.labels" -}}
+helm.sh/chart: {{ include "verdaccio.chart" . }}
+{{ include "verdaccio.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app: {{ include "verdaccio.fullname" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "verdaccio.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "verdaccio.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 
 {{/*
 Create the name of the service account to use
@@ -37,4 +74,98 @@ Usage:
     {{- else }}
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
+{{- end -}}
+
+{{/*
+Pod Labels
+
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "verdaccio.podLabels" . | nindent 8 }}
+*/}}
+{{- define "verdaccio.podLabels" -}}
+  {{- include "verdaccio.labels" . }}
+  {{- $global := .Values.global }}
+  {{- $local := .Values.podLabels }}
+  {{- $labels := dict }}
+  {{- if $global }}
+    {{- range $k,$v := $global.podLabels }}
+      {{- $labels = merge $labels (dict $k (tpl $v $)) }}
+    {{- end }}
+  {{- end }}
+  {{- if $local }}
+    {{- range $k,$v := $local }}
+      {{- $labels = merge $labels (dict $k (tpl $v $)) }}
+    {{- end }}
+  {{- end }}
+  {{- if (not (empty $labels)) }}
+    {{- toYaml $labels }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Pod Annotations
+
+spec:
+  template:
+    metadata:
+      annotations:
+        {{- include "verdaccio.podAnnotations" . | nindent 8 }}
+*/}}
+{{- define "verdaccio.podAnnotations" -}}
+  {{- $global := .Values.global }}
+  {{- $local := .Values.podAnnotations }}
+  {{- $annotations := dict }}
+  {{- if $global }}
+    {{- range $k,$v := $global.podAnnotations }}
+      {{- $annotations = merge $annotations (dict $k (tpl $v $)) }}
+    {{- end }}
+  {{- end -}}
+  {{- if $local }}
+    {{- range $k,$v := $local }}
+      {{- $annotations = merge $annotations (dict $k (tpl $v $)) }}
+    {{- end }}
+  {{- end -}}
+  {{- if (not (empty $annotations)) }}
+    {{- toYaml $annotations }}
+  {{- end }}
+{{- end }}
+
+{{/*
+# templates/deployment.yaml
+spec:
+  template:
+    spec:
+      {{- include "verdaccio.imagePullSecrets" . | nindent 6 }}
+
+# values.yaml
+image:
+  pullSecrets:
+  - mypullsecret
+*/}}
+{{- define "verdaccio.imagePullSecrets" -}}
+  {{- $images := .Values.image }}
+  {{- $global := .Values.global }}
+  {{- $pullSecrets := list }}
+
+  {{- if $global }}
+    {{- if $global.image }}
+      {{- range $global.image.pullSecrets -}}
+        {{- $pullSecrets = append $pullSecrets . -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- range $images.pullSecrets -}}
+    {{- $pullSecrets = append $pullSecrets . -}}
+  {{- end -}}
+
+  {{- if (not (empty $pullSecrets)) }}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+  - name: {{ . }}
+    {{- end }}
+  {{- end }}
 {{- end -}}

--- a/charts/verdaccio/templates/configmap.yaml
+++ b/charts/verdaccio/templates/configmap.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "verdaccio.fullname" . }}
   labels:
-    app: {{ template "verdaccio.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "verdaccio.labels" . | nindent 4 }}
 data:
   config.yaml: |-
-{{ .Values.configMap | indent 4 }}
+    {{- include "tplvalues.render" (dict "value" .Values.configMap "context" $) | nindent 4 }}

--- a/charts/verdaccio/templates/deployment.yaml
+++ b/charts/verdaccio/templates/deployment.yaml
@@ -1,18 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    app: {{ template "verdaccio.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
   name: {{ template "verdaccio.fullname" . }}
+  labels:
+    {{- include "verdaccio.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ default 1 .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "verdaccio.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "verdaccio.selectorLabels" . | nindent 6 }}
   strategy:
     {{- if .Values.persistence.enabled }}
     type: Recreate
@@ -24,17 +20,20 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-    {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-    {{- end }}
+        {{- include "verdaccio.podAnnotations" . | nindent 8 }}
       labels:
-        app: {{ template "verdaccio.name" . }}
-        release: {{ .Release.Name }}
-        {{- if .Values.podLabels }}
-        {{- include "tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
-        {{- end }}        
+        {{- include "verdaccio.podLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "verdaccio.serviceAccountName" . }}
+      {{- include "verdaccio.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "verdaccio.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -52,39 +51,35 @@ spec:
               path: /-/ping
               port: http
             initialDelaySeconds: 5
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
-{{- if .Values.persistence.mounts }}
-{{ toYaml .Values.persistence.mounts | indent 12 }}
-{{- end }}
+            {{- with .Values.persistence.mounts }}
+            {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
+            {{- end }}
             - mountPath: /verdaccio/storage
               name: storage
               readOnly: false
             - mountPath: /verdaccio/conf
               name: config
               readOnly: true
+          {{- with .Values.extraEnvVars }}
           env:
-{{- if .Values.extraEnvVars }}
-{{ toYaml .Values.extraEnvVars | indent 12 }}
-{{- end }}
-      {{- if .Values.image.pullSecrets }}
-      imagePullSecrets:
-{{ toYaml .Values.image.pullSecrets | indent 8 }}
-      {{- end }}
-      {{- if .Values.securityContext.enabled }}
-      # Allow non-root user to access PersistentVolume
-      securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-      {{- end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
       - name: config
         configMap:
           name: {{ .Values.existingConfigMap | default (include "verdaccio.fullname" .) }}
-{{- if .Values.persistence.volumes }}
-{{ toYaml .Values.persistence.volumes | indent 6 }}
-{{- end }}
+      {{- with .Values.persistence.volumes }}
+      {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 6 }}
+      {{- end }}
       - name: storage
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
@@ -94,15 +89,15 @@ spec:
       {{- end -}}
     {{- if .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+        {{- toYaml .Values.affinity | nindent 8 }}
     {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
     {{- end }}
     {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+      {{- toYaml .Values.tolerations | nindent 8 }}
     {{- end }}
     {{- if .Values.priorityClass.enabled }}
       priorityClassName: {{ .Values.priorityClass.name }}

--- a/charts/verdaccio/templates/ingress.yaml
+++ b/charts/verdaccio/templates/ingress.yaml
@@ -12,10 +12,7 @@ kind: Ingress
 metadata:
   name: {{ template "verdaccio.fullname" . }}
   labels:
-    app: {{ template "verdaccio.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "verdaccio.labels" . | nindent 4 }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
@@ -24,7 +21,7 @@ spec:
   rules:
     {{- if .Values.ingress.hosts }}
     {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host }}
+    - host: {{ include "tplvalues.render" (dict "value" $host "context" $) }}
       http:
         paths:
           {{- range $ingressExtraPaths }}
@@ -52,6 +49,6 @@ spec:
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
   {{- end -}}
 {{- end}}

--- a/charts/verdaccio/templates/ingress.yaml
+++ b/charts/verdaccio/templates/ingress.yaml
@@ -13,15 +13,15 @@ metadata:
   name: {{ template "verdaccio.fullname" . }}
   labels:
     {{- include "verdaccio.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
+    {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   rules:
     {{- if .Values.ingress.hosts }}
     {{- range $host := .Values.ingress.hosts }}
-    - host: {{ include "tplvalues.render" (dict "value" $host "context" $) }}
+    - host: {{ tpl $host $ }}
       http:
         paths:
           {{- range $ingressExtraPaths }}

--- a/charts/verdaccio/templates/pvc.yaml
+++ b/charts/verdaccio/templates/pvc.yaml
@@ -2,27 +2,25 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  labels:
-    app: {{ template "verdaccio.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
   name: {{ template "verdaccio.fullname" . }}
+  labels:
+    {{- include "verdaccio.labels" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-{{- if .Values.persistence.storageClass }}
-{{- if (eq "-" .Values.persistence.storageClass) }}
+  {{- if .Values.persistence.storageClass }}
+    {{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""
-{{- else }}
+    {{- else }}
   storageClassName: "{{ .Values.persistence.storageClass }}"
-{{- end }}
-{{- end }}
-{{- if .Values.persistence.selector }}
-  selector: {{- include "tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 4 }}
-{{- end -}}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.persistence.selector }}
+  selector:
+    {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end -}}
 
 {{- end }}

--- a/charts/verdaccio/templates/service-account.yaml
+++ b/charts/verdaccio/templates/service-account.yaml
@@ -5,10 +5,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "verdaccio.serviceAccountName" . }}
   labels:
-    app: {{ template "verdaccio.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "verdaccio.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/verdaccio/templates/service.yaml
+++ b/charts/verdaccio/templates/service.yaml
@@ -7,10 +7,7 @@ metadata:
 {{- end }}
   name: {{ template "verdaccio.fullname" . }}
   labels:
-    app: {{ template "verdaccio.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "verdaccio.labels" . | nindent 4 }}
 spec:
 {{- if .Values.service.clusterIP }}
   clusterIP: "{{ .Values.service.clusterIP }}"
@@ -37,6 +34,5 @@ spec:
       {{- end }}
       {{- end }}
   selector:
-    app: {{ template "verdaccio.name" . }}
-    release: {{ .Release.Name }}
+    {{- include "verdaccio.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}

--- a/charts/verdaccio/templates/service.yaml
+++ b/charts/verdaccio/templates/service.yaml
@@ -1,28 +1,28 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.service.annotations }}
-  annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
   name: {{ template "verdaccio.fullname" . }}
   labels:
     {{- include "verdaccio.labels" . | nindent 4 }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
-{{- if .Values.service.clusterIP }}
+  {{- if .Values.service.clusterIP }}
   clusterIP: "{{ .Values.service.clusterIP }}"
-{{- end }}
-{{- if .Values.service.externalIPs }}
+  {{- end }}
+  {{- if .Values.service.externalIPs }}
   externalIPs:
-{{ toYaml .Values.service.externalIPs | indent 4 }}
-{{- end }}
-{{- if .Values.service.loadBalancerIP }}
+    {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
-{{- end }}
-{{- if .Values.service.loadBalancerSourceRanges }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
-{{- end }}
+    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -5,6 +5,9 @@ image:
   pullSecrets: []
     # - dockerhub-secret
 
+nameOverride: ""
+fullnameOverride: ""
+
 service:
   annotations: {}
   clusterIP: ""
@@ -38,7 +41,7 @@ tolerations: []
 ##
 podLabels: {}
 
-## Additional pod annoations
+## Additional pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -2,8 +2,8 @@ image:
   repository: verdaccio/verdaccio
   tag: 4.12.0
   pullPolicy: IfNotPresent
-  pullSecrets:
-    # name: dockerhub-secret
+  pullSecrets: []
+    # - dockerhub-secret
 
 service:
   annotations: {}
@@ -38,17 +38,20 @@ tolerations: []
 ##
 podLabels: {}
 
+## Additional pod annoations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
 podAnnotations: {}
+
 replicaCount: 1
 
-resources:
-  {}
-  # limits:
-  #  cpu: 100m
-  #  memory: 512Mi
+resources: {}
   # requests:
-  #  cpu: 100m
-  #  memory: 512Mi
+  #   cpu: 100m
+  #   memory: 512Mi
+  # limits:
+  #   cpu: 100m
+  #   memory: 512Mi
 
 ingress:
   enabled: false
@@ -87,6 +90,9 @@ extraEnvVars:
 #        key: secret_key
 #  - name: REGULAR_VAR
 #    value: ABC
+
+# Extra Init Containers - allows yaml definitions
+extraInitContainers: []
 
 configMap: |
   # This is the config file used for the docker images.
@@ -184,12 +190,12 @@ persistence:
   #  - name: nothing
   #    emptyDir: {}
   mounts:
-#  - mountPath: /var/nothing
-#    name: nothing
-#    readOnly: true
+  # - mountPath: /var/nothing
+  #   name: nothing
+  #   readOnly: true
 
+podSecurityContext: {}
 securityContext:
-  enabled: true
   runAsUser: 10001
   fsGroup: 101
 

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -194,10 +194,10 @@ persistence:
   #   name: nothing
   #   readOnly: true
 
-podSecurityContext: {}
+podSecurityContext:
+  fsGroup: 101
 securityContext:
   runAsUser: 10001
-  fsGroup: 101
 
 priorityClass:
   enabled: false


### PR DESCRIPTION
We're using this chart internally as an NPM Registry and we were doing some refactoring on it and I figured that some of the changes we made might be useful to you.

* Instead of hard-coding Labels and Selector Labels, use a `helper` to pull them through
* Use the standard `helm create chart` generated helper utils
* Template the `config` in the Config Map
* Add `extraInitContainers` to the Deployment
* Template the `persistence.volumes` and `persistence.mounts`
* Use the Helm `nindent` standard instead of `indent`
* Add support for some Global values (`podAnnotations`, `podLabels`, `pullSecrets`)
* Template `podLabels` and `podAnnotations` values
* Pass `extraInitContainers` to Template helper
