### PR TITLE
feat: Ingress v1 API Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ and their default values.
 | `fullnameOverride`                 | Set resource fullname override                                                     | `""`                           |
 | `useSecretHtpasswd`                | Use htpasswd from `.Values.secrets.htpasswd`. This require helm v3.2.0 or above.   | `false`                        |
 | `secrets.htpasswd`                 | user and password list to generate htpasswd.                                       | `[]`                           |
+| `ingress.enabled`                  | Enable/Disable Ingress                                                             | `false                         |
+| `ingress.className`                | Ingress Class Name (k8s `>=1.18` required)                                         | `""`                           |
+| `ingress.annotations`              | Ingress Annotations                                                                | `{}`                           |
+| `ingress.hosts`                    | List of Ingress Hosts                                                              | `[]`                           |
+| `ingress.paths`                    | List of Ingress Paths                                                              | `["/"]`                        |
+| `ingress.extraPaths`               | List of extra Ingress Paths                                                        | `[]`                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ and their default values.
 | `fullnameOverride`                 | Set resource fullname override                                                     | `""`                           |
 | `useSecretHtpasswd`                | Use htpasswd from `.Values.secrets.htpasswd`. This require helm v3.2.0 or above.   | `false`                        |
 | `secrets.htpasswd`                 | user and password list to generate htpasswd.                                       | `[]`                           |
-| `ingress.enabled`                  | Enable/Disable Ingress                                                             | `false                         |
+| `ingress.enabled`                  | Enable/Disable Ingress                                                             | `false`                        |
 | `ingress.className`                | Ingress Class Name (k8s `>=1.18` required)                                         | `""`                           |
 | `ingress.annotations`              | Ingress Annotations                                                                | `{}`                           |
 | `ingress.hosts`                    | List of Ingress Hosts                                                              | `[]`                           |

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.3.0
+version: 4.4.0
 appVersion: 5.1.1
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/ingress.yaml
+++ b/charts/verdaccio/templates/ingress.yaml
@@ -1,16 +1,23 @@
 {{- if .Values.ingress.enabled }}
-{{- $serviceName := include "verdaccio.fullname" . -}}
-{{- $servicePort := .Values.service.port -}}
+{{- $fullName := include "verdaccio.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
 {{- $paths := .Values.ingress.paths -}}
 {{- $ingressExtraPaths := .Values.ingress.extraPaths -}}
-{{- if .Values.ingress.useExtensionsApi }}
-apiVersion: extensions/v1beta1
-{{- else }}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ template "verdaccio.fullname" . }}
+  name: {{ $fullName }}
   labels:
     {{- include "verdaccio.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -18,34 +25,63 @@ metadata:
     {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
     {{- if .Values.ingress.hosts }}
     {{- range $host := .Values.ingress.hosts }}
-    - host: {{ tpl $host $ }}
+    - host: {{ tpl $host $ | quote }}
       http:
         paths:
-          {{- range $ingressExtraPaths }}
+        {{- range $ingressExtraPaths }}
           - path: {{ default "/" .path | quote }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
-              serviceName: {{ default $serviceName .service }}
-              servicePort: {{ default $servicePort .port }}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ default $fullName .service }}
+                port:
+                  number: {{ default $svcPort .port }}
+              {{- else }}
+              serviceName: {{ default $fullName .service }}
+              servicePort: {{ default $svcPort .port }}
+              {{- end }}
           {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end -}}
-    {{- end -}}
+        {{- end -}}
     {{- else }}
     - http:
         paths:
-    {{- range $p := $paths }}
+        {{- range $p := $paths }}
           - path: {{ $p }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-    {{- end -}}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end -}}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -58,8 +58,7 @@ resources: {}
 
 ingress:
   enabled: false
-  # Set to true if you are on an old cluster where apiVersion extensions/v1beta1 is required
-  useExtensionsApi: false
+  className: ""
   paths:
     - /
   # Use this to define, ALB ingress's actions annotation based routing. Ex: for ssl-redirect


### PR DESCRIPTION
* Remove `ingress.useExtensionsApi`
* Add `ingress.className`
* Auto-detect k8s version to figure out appropriate Ingress API Version
* Update Readme with missing ingress config

This adds support for `networking.k8s.io/v1` for Ingresses, added in
k8s `1.19` and required in `1.22`