### PR TITLE
Added check to only apply pathType on k8s >= 1.18

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.6.0
+version: 4.6.1
 appVersion: 5.5.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/ingress.yaml
+++ b/charts/verdaccio/templates/ingress.yaml
@@ -52,7 +52,9 @@ spec:
           {{- end }}
           {{- range $p := $paths }}
           - path: {{ $p }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
+            {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:


### PR DESCRIPTION
Currently, deployment fails for Kubernetes Clusters running on versions <1.18, as the old networking namespace haven't had the `pathType` field included. 

I added a check around the field for normal path's, just as it already was for extraPath's.