### PR TITLE
Bugfix: Fix Missing Newline in PodLabels

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.6.1
+version: 4.6.2
 appVersion: 5.5.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/_helpers.tpl
+++ b/charts/verdaccio/templates/_helpers.tpl
@@ -101,7 +101,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- if (not (empty $labels)) }}
-    {{- toYaml $labels }}
+    {{- toYaml $labels | nindent 0 }}
   {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
* Use `nindnet 0` to insert a newline with the `verdaccio.podLabels`
  helper

Fixes #89 