### PR TITLE
fix: error when ".Values.configMap" includes "{{}}"

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.6.2
+version: 4.6.3
 appVersion: 5.5.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/configmap.yaml
+++ b/charts/verdaccio/templates/configmap.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "verdaccio.labels" . | nindent 4 }}
 data:
   config.yaml: |-
-    {{- include "tplvalues.render" (dict "value" .Values.configMap "context" $) | nindent 4 }}
+    {{- include "tplvalues.render" (dict "value" (printf "{{.Values.configMap}}") "context" $) | nindent 4 }}


### PR DESCRIPTION
Currently, Helm will failed to render template when `.Values.configMap` includes `{{}}`, for example, I'm using `verdaccio-ldap` plugin and my config includes:
```yaml
configMap: |
  auth:
	  ldap:
		  client_options:
			  searchFilter: "(uid={{username}})"
```

Which will give me this error:
```
template: verdaccio/templates/deployment.yaml:22:28: executing "verdaccio/templates/deployment.yaml" at <include (print $.Template.BasePath "/configmap.yaml") .>: error calling include: template: verdaccio/templates/configmap.yaml:9:8: executing "verdaccio/templates/configmap.yaml" at <include "tplvalues.render" (dict "value" .Values.configMap "context" $)>: error calling include: template: verdaccio/templates/_helpers.tpl:73:12: executing "tplvalues.render" at <tpl .value .context>: error calling tpl: error during tpl function execution for
```

This PR fix the issue by escaping `.Values.configMap` before passing it to a function.

See: https://github.com/helm/helm/issues/2798#issuecomment-518207645
