### PR TITLE
Bugfix: Fix image tag

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.7.0
+version: 4.7.1
 appVersion: 5.5.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/deployment.yaml
+++ b/charts/verdaccio/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "verdaccio.name" . }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: 4873

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: verdaccio/verdaccio
-  tag: 5.2.0
+  # tag: 5.5.0
   pullPolicy: IfNotPresent
   pullSecrets: []
     # - dockerhub-secret


### PR DESCRIPTION
* Image tag was still `5.2.0` even though `appVersion=5.5.0`
* Updated deployment to default to Chart App Version