### PR TITLE
Update default extraEnvVars

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.15.0
+version: 4.16.0
 appVersion: 5.29.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -99,7 +99,7 @@ serviceAccount:
   name: ""
 
 # Extra Environment Values - allows yaml definitions
-extraEnvVars:
+# extraEnvVars:
 #  - name: VALUE_FROM_SECRET
 #    valueFrom:
 #      secretKeyRef:
@@ -107,6 +107,9 @@ extraEnvVars:
 #        key: secret_key
 #  - name: REGULAR_VAR
 #    value: ABC
+extraEnvVars:
+  - name: VERDACCIO_PORT
+    value: "4873"
 
 ## Secret Environment Variables
 ## Use this to pass sensitive key:values to the container via k8s secret


### PR DESCRIPTION
Fix CrashLoopBackOff errror
```
 warn --- config file  - /verdaccio/conf/config.yaml
 warn --- Plugin successfully loaded: verdaccio-htpasswd
 warn --- Plugin successfully loaded: verdaccio-audit
 warn --- invalid address - http://0.0.0.0:tcp://10.230.80.202:4873, we expect a port (e.g. "4873"), host:port (e.g. "localhost:4873") or full url (e.g. "http://localhost:4873/")
```