### PR TITLE
chore: fix install cmd error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ```
 $ helm repo add verdaccio https://charts.verdaccio.org
 $ helm repo update
-$ helm install verdaccio/verdaccio
+$ helm install verdaccio verdaccio/verdaccio
 ```
 
 > ⚠️ If you are using **stable/verdaccio** chart, [be aware is deprecated](https://github.com/helm/charts/pull/21929), forward all new PR and or issues to this repository.


### PR DESCRIPTION
`helm install verdaccio/verdaccio`  will got error: 
```sh
Error: INSTALLATION FAILED: must either provide a name or specify --generate-name
```

I added the missing name for the chart release.