### PR TITLE
feat: update image to v5.21.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ helm install npm verdaccio/verdaccio
 
 ```bash
 # Helm v3+
-helm install npm --set image.tag=5.18.0 verdaccio/verdaccio
+helm install npm --set image.tag=5.21.1 verdaccio/verdaccio
 ```
 
 ### Upgrading Verdaccio
@@ -88,7 +88,7 @@ and their default values.
 | `image.pullPolicy`                 | Image pull policy                                                                | `IfNotPresent`                 |
 | `image.pullSecrets`                | Image pull secrets                                                               | `[]`                           |
 | `image.repository`                 | Verdaccio container image repository                                             | `verdaccio/verdaccio`          |
-| `image.tag`                        | Verdaccio container image tag                                                    | `5.18.0`                       |
+| `image.tag`                        | Verdaccio container image tag                                                    | `5.21.1`                       |
 | `nodeSelector`                     | Node labels for pod assignment                                                   | `{}`                           |
 | `tolerations`                      | List of node taints to tolerate                                                  | `[]`                           |
 | `persistence.accessMode`           | PVC Access Mode for Verdaccio volume                                             | `ReadWriteOnce`                |

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
 version: 4.10.3
-appVersion: 5.18.0
+appVersion: 5.21.1
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png
 sources:

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.10.3
+version: 4.11.0
 appVersion: 5.21.1
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: verdaccio/verdaccio
-  # tag: 5.18.0
+  # tag: 5.21.1
   pullPolicy: IfNotPresent
   pullSecrets: []
     # - dockerhub-secret

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -187,8 +187,8 @@ configMap: |
       enabled: true
 
   # log settings
-  logs: {type: stdout, format: pretty, level: http}
-  # logs: {type: file, path: verdaccio.log, level: info}
+  log: {type: stdout, format: pretty, level: http}
+  # log: {type: file, path: verdaccio.log, level: info}
 
 persistence:
   enabled: true


### PR DESCRIPTION
Be aware of a new deprecation warning introduced here https://github.com/verdaccio/verdaccio/releases/tag/v5.22.1 this PR update the default Chart log configuration but still backward compatible, read release for more details.