### PR TITLE
add revision history limit

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.12.0
+version: 4.13.0
 appVersion: 5.21.1
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/deployment.yaml
+++ b/charts/verdaccio/templates/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ default 1 .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "verdaccio.selectorLabels" . | nindent 6 }}

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -48,6 +48,8 @@ podAnnotations: {}
 
 replicaCount: 1
 
+revisionHistoryLimit: 10
+
 ## Define Probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
 livenessProbe: {}


### PR DESCRIPTION
I would like to be able to change the default `revisionHistoryLimit` which is by default 10 :
https://kubernetes.io/docs/concepts/workloads/controllers/deployment/

I don't need to be able to roll back 10 times, would much rather have the performance.
This is of course different from user to user, which is why I want to have it as a variable.

From source:
![image](https://github.com/verdaccio/charts/assets/47821325/b3e11240-5b99-460a-9615-90a402162586)

