### PR TITLE
remove(deployment): the 'replicas' field from the helm template if not used by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ and their default values.
 | `priorityClass.enabled`            | Enable specifying pod priorityClassName                                          | `false`                        |
 | `priorityClass.name`               | PriorityClassName to be specified in pod spec                                    | `""`                           |
 | `replicaCount`                     | Desired number of pods                                                           | `1`                            |
+| `replicaCountEnabled`              | Enable the replicaCount field                                                    | `true`                         |
 | `livenessProbe`                    | Configuration of liveness probe                                                  | `{}`                           |
 | `readinessProbe`                   | Configuration of readiness probe                                                 | `{}`                           |
 | `resources`                        | CPU/Memory resource requests/limits                                              | `{}`                           |

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.16.0
+version: 4.16.1
 appVersion: 5.29.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/deployment.yaml
+++ b/charts/verdaccio/templates/deployment.yaml
@@ -9,8 +9,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not (eq nil .Values.replicaCount) }}
-  replicas: {{ .Values.replicaCount }}
+  {{- if .Values.replicaCountEnabled }}
+  replicas: {{ default 1 .Values.replicaCount }}
   {{- end}}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:

--- a/charts/verdaccio/templates/deployment.yaml
+++ b/charts/verdaccio/templates/deployment.yaml
@@ -9,7 +9,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ default 1 .Values.replicaCount }}
+  {{- if not (eq nil .Values.replicaCount) }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end}}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -46,6 +46,7 @@ podLabels: {}
 ##
 podAnnotations: {}
 
+replicaCountEnabled: true
 replicaCount: 1
 
 revisionHistoryLimit: 10


### PR DESCRIPTION
## What does this MR do?

Remove the 'replicas' field from the helm template if set to null by user.

## Why was this MR needed?

If you are using Keda to auto-scale your runner, it will modify the 'spec.replicas' of the deployment. That will cause a drift from the manifest known to ArgoCD. Therefore ArgoCD resync the resource. But then Keda retry to update it, and so on.....

By modifing the deployment template, we ensure that the replicas field is not present in the helm template if set to null by the user, and therefore not watch by ArgoCD. Note that by default, Kubernetes will set de 'spec.replicas' field to 1 if not present.

## What's the best way to test this MR?

Do three helm template:
  - One with replicaCount to 1
  - One with replicaCount to 0
  - One with replicaCount to null