### PR TITLE
feat: allow adding extra ports and manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ and their default values.
 | `ingress.hosts`                    | List of Ingress Hosts                                                            | `[]`                           |
 | `ingress.paths`                    | List of Ingress Paths                                                            | `["/"]`                        |
 | `ingress.extraPaths`               | List of extra Ingress Paths                                                      | `[]`                           |
+| `extraPorts`                       | List of extra ports to expose from the pods                                      | `[]`                           |
+| `extraManifests`                   | List of extra manifests to deploy within the chart                               | `[]`                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.17.0
+version: 4.18.0
 appVersion: 5.31.1
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/deployment.yaml
+++ b/charts/verdaccio/templates/deployment.yaml
@@ -63,6 +63,10 @@ spec:
           ports:
             - containerPort: 4873
               name: http
+            {{- range .Values.extraPorts }}
+            - containerPort: {{ .port }}
+              name: {{ .targetPort }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /-/ping

--- a/charts/verdaccio/templates/extra-manifests.yaml
+++ b/charts/verdaccio/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraManifests }}
+---
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/charts/verdaccio/templates/service.yaml
+++ b/charts/verdaccio/templates/service.yaml
@@ -27,12 +27,25 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+      {{- if .Values.service.name }}
       name: {{ .Values.service.name }}
+      {{- end }}
       {{- if contains "NodePort" .Values.service.type }}
       {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
       {{- end }}
+    {{- range .Values.extraPorts }}
+    - port: {{ .port }}
+      {{- if .name }}
+      name: {{ .name }}
+      {{- end }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol | default "TCP" }}
+      {{- if .nodePort }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
+    {{- end }}
   selector:
     {{- include "verdaccio.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}

--- a/charts/verdaccio/templates/service.yaml
+++ b/charts/verdaccio/templates/service.yaml
@@ -27,9 +27,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      {{- if .Values.service.name }}
       name: {{ .Values.service.name }}
-      {{- end }}
       {{- if contains "NodePort" .Values.service.type }}
       {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}

--- a/charts/verdaccio/templates/service.yaml
+++ b/charts/verdaccio/templates/service.yaml
@@ -27,7 +27,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      name: {{ .Values.service.name }}
+      name: {{ .Values.service.name | default "http"}}
       {{- if contains "NodePort" .Values.service.type }}
       {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -259,11 +259,11 @@ topologySpreadConstraints: []
 # Extra ports to expose from the pod
 extraPorts: []
   # Example to add a metrics port to the pod and service
-  # - port: 8080 # Port to expose on the pod
+  # - port: 9090 # Port to expose on the pod
   #   name: metrics # Name of the port in the service
   #   targetPort: metrics # Name of the port in the pod and in the targetPort for the service
   #   protocol: TCP # Optional, defaults to TCP
-  #   nodePort: 30080 # Optional
+  #   nodePort: 30090 # Optional
 
 # Additional manifests to deploy within the chart
 ## Can be useful to deploy additional secrets, serviceMonitors, etc

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -255,3 +255,26 @@ annotations: {}
 ## Pod Topology Spread Constraints
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
 topologySpreadConstraints: []
+
+# Extra ports to expose from the pod
+extraPorts: []
+  # Example to add a metrics port to the pod and service
+  # - port: 8080 # Port to expose on the pod
+  #   name: metrics # Name of the port in the service
+  #   targetPort: metrics # Name of the port in the pod and in the targetPort for the service
+  #   protocol: TCP # Optional, defaults to TCP
+  #   nodePort: 30080 # Optional
+
+# Additional manifests to deploy within the chart
+## Can be useful to deploy additional secrets, serviceMonitors, etc
+extraManifests: []
+  # - apiVersion: monitoring.coreos.com/v1
+  #   kind: ServiceMonitor
+  #   metadata:
+  #     name: verdaccio
+  #   spec:
+  #     selector:
+  #       matchLabels:
+  #         app: verdaccio
+  #     endpoints:
+  #     - port: metrics


### PR DESCRIPTION
# Motivation
In order to add metrics thanks to the plugin https://github.com/freight-hub/verdaccio-openmetrics, we need to expose the ports.

# Changes made
- Add a `extraPorts` value, that contain a list of ports to add to the service and container.
- Add a `extraManifests` value, that contain a list of kubernetes manifests to deploy within the chart. This is very useful to, for example, add a ServiceMonitor so the service is scraped by prometheus.
- (fix) Add a default name (http) for the service port.

# Notes
This is not a breaking change, as the new variables are a list with a default empty one and there is a range to iterate over them.