### PR TITLE
Allow keeping the data volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,14 @@ and their default values.
 | `nodeSelector`                     | Node labels for pod assignment                                                   | `{}`                           |
 | `tolerations`                      | List of node taints to tolerate                                                  | `[]`                           |
 | `persistence.accessMode`           | PVC Access Mode for Verdaccio volume                                             | `ReadWriteOnce`                |
+| `persistence.annotations`          | Annotations to add to the PVC                                                    | `{}`                           |
 | `persistence.enabled`              | Enable persistence using PVC                                                     | `true`                         |
 | `persistence.existingClaim`        | Use existing PVC                                                                 | `nil`                          |
 | `persistence.mounts`               | Additional mounts                                                                | `nil`                          |
+| `persistence.resourcePolicy`       | Set "keep" to avoid removing PVC during a helm delete operation                  | `""`                           |
+| `persistence.selector`             | Selector to match an existing Persistent Volume                                  | `{}` (evaluated as a template) |
 | `persistence.size`                 | PVC Storage Request for Verdaccio volume                                         | `8Gi`                          |
 | `persistence.storageClass`         | PVC Storage Class for Verdaccio volume                                           | `nil`                          |
-| `persistence.selector`             | Selector to match an existing Persistent Volume                                  | `{}` (evaluated as a template) |
 | `persistence.volumes`              | Additional volumes                                                               | `nil`                          |
 | `topologySpreadConstraints`        | Topology Spread Constraints for pod assignment                                   | `[]`                           |
 | `podLabels`                        | Additional pod labels                                                            | `{}` (evaluated as a template) |

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.20.0
+version: 4.21.0
 appVersion: 6.0.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/pvc.yaml
+++ b/charts/verdaccio/templates/pvc.yaml
@@ -3,6 +3,13 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "verdaccio.fullname" . }}
+  annotations:
+  {{- range $key, $value := .Values.persistence.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- if eq .Values.persistence.resourcePolicy "keep" }}
+    helm.sh/resource-policy: keep
+  {{- end }}
   labels:
     {{- include "verdaccio.labels" . | nindent 4 }}
 spec:

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -214,6 +214,10 @@ persistence:
 
   accessMode: ReadWriteOnce
   size: 8Gi
+  annotations: {}
+  # Set it to "keep" to avoid removing PVC during a helm delete operation.
+  # Leaving it empty will delete PVC after the chart has been deleted.
+  resourcePolicy: ""
   ## selector can be used to match an existing PersistentVolume
   ## selector:
   ##   matchLabels:


### PR DESCRIPTION
This commit makes it possible to add custom annotations to the PVC and introduces a new property that allows keeping the data volume on a Helm uninstall operation.