### PR TITLE
feat: Provide ability to create statefulset

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ and their default values.
 
 | Parameter                          | Description                                                                      | Default                        |
 | ---------------------------------- | -------------------------------------------------------------------------------- | ------------------------------ |
+| `type`                             | The type of resource to create. Either `deployment` or `statefulset`. Note: Statefulset is primarly useful when Verdaccio is being used as an edge cache | `deployment` |
 | `annotations`                      | Annotations to set on the deployment                                             | `{}`                           |
 | `affinity`                         | Affinity for pod assignment                                                      | `{}`                           |
 | `existingConfigMap`                | Name of custom ConfigMap to use                                                  | `false`                        |
@@ -94,7 +95,7 @@ and their default values.
 | `tolerations`                      | List of node taints to tolerate                                                  | `[]`                           |
 | `persistence.accessMode`           | PVC Access Mode for Verdaccio volume                                             | `ReadWriteOnce`                |
 | `persistence.enabled`              | Enable persistence using PVC                                                     | `true`                         |
-| `persistence.existingClaim`        | Use existing PVC                                                                 | `nil`                          |
+| `persistence.existingClaim`        | Use existing PVC. Ignored when `type` is `statefuleset`                                                                | `nil`                          |
 | `persistence.mounts`               | Additional mounts                                                                | `nil`                          |
 | `persistence.size`                 | PVC Storage Request for Verdaccio volume                                         | `8Gi`                          |
 | `persistence.storageClass`         | PVC Storage Class for Verdaccio volume                                           | `nil`                          |
@@ -222,7 +223,7 @@ $ helm install npm \
 
 Due to some breaking changes in Selector Labels and Security Contexts in Chart `3.0.0` you will need to migrate when upgrading.
 
-First off, the `securityContext.enabled` field has been removed.  
+First off, the `securityContext.enabled` field has been removed.
 In addition to this, `fsGroup` is not a valid Container Security Context field and has been migrated to the `podSecurityContext` instead.
 
 ```diff
@@ -235,8 +236,8 @@ podSecurityContext:
    runAsUser: 10001
 ```
 
-Secondly, the `apps.v1.Deployment.spec.selector` field is immutable and changes were made to Selector Labels which tries to update this.  
-To get around this, you will need to `kubectl delete deployment $deploymentName` before doing a `helm upgrade`  
+Secondly, the `apps.v1.Deployment.spec.selector` field is immutable and changes were made to Selector Labels which tries to update this.
+To get around this, you will need to `kubectl delete deployment $deploymentName` before doing a `helm upgrade`
 So long as your PVC is not destroyed, the new deployment will be rolled out with the same PVC as before and your data will remain intact.
 
 ### Migrating chart 3.x -> 4.x

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.20.0
+version: 4.21.0
 appVersion: 6.0.0
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/pvc.yaml
+++ b/charts/verdaccio/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+{{- if and (eq .Values.type "deployment") (and .Values.persistence.enabled (not .Values.persistence.existingClaim)) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/verdaccio/templates/statefulset.yaml
+++ b/charts/verdaccio/templates/statefulset.yaml
@@ -1,6 +1,6 @@
-{{- if eq .Values.type "deployment" }}
+{{- if eq .Values.type "statefulset" -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "verdaccio.fullname" . }}
   labels:
@@ -10,20 +10,17 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  serviceName: {{ template "verdaccio.fullname" . }}
   {{- if .Values.replicaCountEnabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- else }}
+  replicas: 1
   {{- end}}
-  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "verdaccio.selectorLabels" . | nindent 6 }}
-  strategy:
-    {{- if .Values.persistence.enabled }}
-    type: Recreate
-    rollingUpdate: null
-    {{- else }}
+  updateStrategy:
     type: RollingUpdate
-    {{- end }}
   template:
     metadata:
       annotations:
@@ -155,13 +152,6 @@ spec:
       {{- with .Values.persistence.volumes }}
       {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 6 }}
       {{- end }}
-      - name: storage
-      {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (include "verdaccio.fullname" .) }}
-      {{- else }}
-        emptyDir: {}
-      {{- end -}}
     {{- if .Values.affinity }}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
@@ -181,4 +171,17 @@ spec:
       topologySpreadConstraints:
         {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
     {{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: storage
+    spec:
+      accessModes: [ {{ .Values.persistence.accessMode | quote }} ]
+      {{- if (eq "-" .Values.persistence.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: "{{ .Values.persistence.storageClass }}"
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | quote }}
 {{- end -}}

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -5,6 +5,8 @@ image:
   pullSecrets: []
     # - dockerhub-secret
 
+type: deployment
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
When using verdaccio as purely an edge cache, multiple deployment replicas require that the storage PV support ReadWriteMany. However, such PVs are not always available.

A StatefulSet can be used instead, where each replica will have it's own PV. This has the downside that initially the storage will be empty and may take time for them to get populated.

To be clear, Using StatefulSet is primarly useful for when verdaccio is an edge cache; Using it as a regular NPM registry (accepting uploads), would require additional step of syncing artifacts.