### PR TITLE
feat: allow custom labels to ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ and their default values.
 | `secrets.htpasswd`                 | user and password list to generate htpasswd.                                     | `[]`                           |
 | `ingress.enabled`                  | Enable/Disable Ingress                                                           | `false`                        |
 | `ingress.className`                | Ingress Class Name (k8s `>=1.18` required)                                       | `""`                           |
+| `ingress.labels`                   | Ingress Labels                                                                   | `{}`                           |
 | `ingress.annotations`              | Ingress Annotations                                                              | `{}`                           |
 | `ingress.hosts`                    | List of Ingress Hosts                                                            | `[]`                           |
 | `ingress.paths`                    | List of Ingress Paths                                                            | `["/"]`                        |

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.23.0
+version: 4.24.0
 appVersion: 6.0.2
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.22.0
+version: 4.23.0
 appVersion: 6.0.2
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/ingress.yaml
+++ b/charts/verdaccio/templates/ingress.yaml
@@ -20,6 +20,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "verdaccio.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- include "tplvalues.render" (dict "value" . "context" $) | nindent 4 }}

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -82,6 +82,7 @@ ingress:
   # Use this to define, ALB ingress's actions annotation based routing. Ex: for ssl-redirect
   # Ref: https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/tasks/ssl_redirect/
   extraPaths: []
+  labels: {}
 # hosts:
 #   - npm.blah.com
 # annotations:


### PR DESCRIPTION
Adds `ingress.labels` to values, allowing consumers to add custom labels to the ingress.

Our company use labels on ingresses and routes to set them up for traffic from specific domains.