### PR TITLE
chore: prepare verdaccio 7 chart release

### DIFF
--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.32.3
-appVersion: 6.7.4
+version: 5.0.0
+appVersion: 7.0.0-next-7.23
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png
 sources:


### PR DESCRIPTION
Prepare the Helm chart release for Verdaccio 7.x.

Changes:
- Bump chart version to 5.0.0
- Bump appVersion to 7.0.0

References:
- Helm chart release PR: https://github.com/verdaccio/charts/pull/198
- Verdaccio 7 release PR: https://github.com/verdaccio/verdaccio/pull/6065
- Verdaccio 7 tracking issue: https://github.com/verdaccio/verdaccio/issues/5680
- Website docs/update: https://github.com/verdaccio/website/pull/473