### PR TITLE
feat: add HPA & PodDisruptionBudget support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ and their default values.
 | `priorityClass.name`               | PriorityClassName to be specified in pod spec                                    | `""`                           |
 | `replicaCount`                     | Desired number of pods                                                           | `1`                            |
 | `replicaCountEnabled`              | Enable the replicaCount field                                                    | `true`                         |
+| `autoscaling.enabled`              | Enable the HorizontalPodAutoscaler (omits `replicas` so the HPA owns it)         | `false`                        |
+| `autoscaling.minReplicas`          | Minimum number of replicas                                                       | `2`                            |
+| `autoscaling.maxReplicas`          | Maximum number of replicas                                                       | `5`                            |
+| `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                                   | `80`                           |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization percentage                                | none                           |
+| `autoscaling.behavior`             | Scaling behavior policies for the HPA                                            | `{}`                           |
 | `strategy`                         | The deployment strategy field                                                    | If persistence is enabled, the strategy type is set to `Recreate`, otherwise `RollingUpdate` |
 | `livenessProbe`                    | Configuration of liveness probe                                                  | `{}`                           |
 | `readinessProbe`                   | Configuration of readiness probe                                                 | `{}`                           |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ and their default values.
 | `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                                   | `80`                           |
 | `autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization percentage                                | none                           |
 | `autoscaling.behavior`             | Scaling behavior policies for the HPA                                            | `{}`                           |
+| `podDisruptionBudget.enabled`      | Enable a PodDisruptionBudget                                                     | `false`                        |
+| `podDisruptionBudget.minAvailable`    | Minimum number/percentage of pods that must remain available                  | `1`                            |
+| `podDisruptionBudget.maxUnavailable`  | Maximum number/percentage of pods that can be unavailable (mutually exclusive with `minAvailable`) | none           |
 | `strategy`                         | The deployment strategy field                                                    | If persistence is enabled, the strategy type is set to `Recreate`, otherwise `RollingUpdate` |
 | `livenessProbe`                    | Configuration of liveness probe                                                  | `{}`                           |
 | `readinessProbe`                   | Configuration of readiness probe                                                 | `{}`                           |

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ and their default values.
 | `autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization percentage                                | none                           |
 | `autoscaling.behavior`             | Scaling behavior policies for the HPA                                            | `{}`                           |
 | `podDisruptionBudget.enabled`      | Enable a PodDisruptionBudget                                                     | `false`                        |
-| `podDisruptionBudget.minAvailable`    | Minimum number/percentage of pods that must remain available                  | `1`                            |
-| `podDisruptionBudget.maxUnavailable`  | Maximum number/percentage of pods that can be unavailable (mutually exclusive with `minAvailable`) | none           |
+| `podDisruptionBudget.maxUnavailable`  | Maximum number/percentage of pods that can be unavailable                     | `1`                            |
+| `podDisruptionBudget.minAvailable`    | Minimum number/percentage of pods that must remain available (mutually exclusive with `maxUnavailable`) | none         |
 | `strategy`                         | The deployment strategy field                                                    | If persistence is enabled, the strategy type is set to `Recreate`, otherwise `RollingUpdate` |
 | `livenessProbe`                    | Configuration of liveness probe                                                  | `{}`                           |
 | `readinessProbe`                   | Configuration of readiness probe                                                 | `{}`                           |

--- a/charts/verdaccio/Chart.yaml
+++ b/charts/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A lightweight private node.js proxy registry
 name: verdaccio
-version: 4.33.1
+version: 4.34.0
 appVersion: 6.9.2
 home: https://verdaccio.org
 icon: https://cdn.verdaccio.dev/logos/default.png

--- a/charts/verdaccio/templates/_helpers.tpl
+++ b/charts/verdaccio/templates/_helpers.tpl
@@ -53,6 +53,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Workload kind (Deployment or StatefulSet) based on .Values.type
+*/}}
+{{- define "verdaccio.workloadKind" -}}
+{{- if eq .Values.type "statefulset" }}StatefulSet{{ else }}Deployment{{ end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "verdaccio.serviceAccountName" -}}

--- a/charts/verdaccio/templates/deployment.yaml
+++ b/charts/verdaccio/templates/deployment.yaml
@@ -10,9 +10,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   {{- if .Values.replicaCountEnabled }}
   replicas: {{ .Values.replicaCount }}
-  {{- end}}
+  {{- end }}
+  {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/verdaccio/templates/hpa.yaml
+++ b/charts/verdaccio/templates/hpa.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: {{ if eq .Values.type "statefulset" }}StatefulSet{{ else }}Deployment{{ end }}
+    kind: {{ include "verdaccio.workloadKind" . }}
     name: {{ template "verdaccio.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/charts/verdaccio/templates/hpa.yaml
+++ b/charts/verdaccio/templates/hpa.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "verdaccio.fullname" . }}
+  labels:
+    {{- include "verdaccio.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: {{ if eq .Values.type "statefulset" }}StatefulSet{{ else }}Deployment{{ end }}
+    name: {{ template "verdaccio.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/verdaccio/templates/hpa.yaml
+++ b/charts/verdaccio/templates/hpa.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if not (semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- fail "autoscaling requires Kubernetes >= 1.23 (autoscaling/v2)" }}
+{{- end }}
+{{- if and (not .Values.autoscaling.targetCPUUtilizationPercentage) (not .Values.autoscaling.targetMemoryUtilizationPercentage) }}
+{{- fail "autoscaling: at least one of targetCPUUtilizationPercentage or targetMemoryUtilizationPercentage must be set" }}
+{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/verdaccio/templates/pdb.yaml
+++ b/charts/verdaccio/templates/pdb.yaml
@@ -1,5 +1,15 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
+{{- fail "podDisruptionBudget: minAvailable and maxUnavailable are mutually exclusive, set only one" }}
+{{- end }}
+{{- if and (not .Values.podDisruptionBudget.minAvailable) (not .Values.podDisruptionBudget.maxUnavailable) }}
+{{- fail "podDisruptionBudget: one of minAvailable or maxUnavailable must be set" }}
+{{- end }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "verdaccio.fullname" . }}

--- a/charts/verdaccio/templates/pdb.yaml
+++ b/charts/verdaccio/templates/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "verdaccio.fullname" . }}
+  labels:
+    {{- include "verdaccio.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "verdaccio.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/verdaccio/templates/statefulset.yaml
+++ b/charts/verdaccio/templates/statefulset.yaml
@@ -11,11 +11,13 @@ metadata:
   {{- end }}
 spec:
   serviceName: {{ template "verdaccio.fullname" . }}
+  {{- if not .Values.autoscaling.enabled }}
   {{- if .Values.replicaCountEnabled }}
   replicas: {{ .Values.replicaCount }}
   {{- else }}
   replicas: 1
-  {{- end}}
+  {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "verdaccio.selectorLabels" . | nindent 6 }}

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -68,6 +68,16 @@ autoscaling:
   ## Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
   behavior: {}
 
+## Pod Disruption Budget
+## Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+## Keeps a minimum number of pods available during voluntary disruptions
+## (node drains, upgrades). Only meaningful with more than one replica.
+## `minAvailable` and `maxUnavailable` are mutually exclusive; set only one.
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
 revisionHistoryLimit: 10
 
 strategy: {}

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -75,8 +75,8 @@ autoscaling:
 ## `minAvailable` and `maxUnavailable` are mutually exclusive; set only one.
 podDisruptionBudget:
   enabled: false
-  minAvailable: 1
-  # maxUnavailable: 1
+  # minAvailable: 1
+  maxUnavailable: 1
 
 revisionHistoryLimit: 10
 

--- a/charts/verdaccio/values.yaml
+++ b/charts/verdaccio/values.yaml
@@ -51,6 +51,23 @@ podAnnotations: {}
 replicaCountEnabled: true
 replicaCount: 1
 
+## Horizontal Pod Autoscaler
+## Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+## When enabled, the `replicas` field is omitted from the Deployment/StatefulSet so the
+## HPA owns the replica count. This avoids a GitOps controller (e.g. ArgoCD) and the HPA
+## fighting over the replica count.
+## Note: scaling beyond one replica with `persistence.enabled` requires a `type: statefulset`
+## (each pod gets its own volume via volumeClaimTemplates) or a ReadWriteMany storage class.
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+  ## Scaling behavior policies (autoscaling/v2)
+  ## Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
+  behavior: {}
+
 revisionHistoryLimit: 10
 
 strategy: {}


### PR DESCRIPTION
Closes #192

## Summary

When `autoscaling`/HPA is used together with a GitOps controller (e.g. ArgoCD), the chart and the HPA fight over the replica count because the `StatefulSet`/`Deployment` template hardcodes `replicas: 1`. This PR fixes that and adds HPA + PDB support.

## Problem

- The `StatefulSet` template hardcodes `replicas: 1` when `replicaCountEnabled` is `false`.
- An HPA scales the workload up, but the GitOps controller (ArgoCD) resets it back to `1` from the rendered manifest, causing an endless reconcile loop.
- No built-in support for a `HorizontalPodAutoscaler` or `PodDisruptionBudget`.

## Changes

1. **`feat(verdaccio): add HPA and stop hardcoding replicas when autoscaling`**
   - New `autoscaling` block in `values.yaml` and an `hpa.yaml` template (`autoscaling/v2`) targeting either the `Deployment` or `StatefulSet`.
   - When `autoscaling.enabled: true`, the `replicas` field is omitted from the `Deployment`/`StatefulSet` so the HPA owns the replica count (fixes the ArgoCD <-> HPA loop).

2. **`feat(verdaccio): add optional PodDisruptionBudget`**
   - New `pdb.yaml` template (`policy/v1`) gated on `podDisruptionBudget.enabled`, with mutually-exclusive `minAvailable` / `maxUnavailable`. Defaults to `maxUnavailable: 1`.

3. **`refactor(verdaccio): extract workload kind into helper template`**
   - New reusable `verdaccio.workloadKind` helper (Deployment vs StatefulSet) used by the HPA `scaleTargetRef`.

## New values

```yaml
autoscaling:
  enabled: false
  minReplicas: 2
  maxReplicas: 5
  targetCPUUtilizationPercentage: 80
  # targetMemoryUtilizationPercentage: 80
  behavior: {}

podDisruptionBudget:
  enabled: false
  # minAvailable: 1
  maxUnavailable: 1
```

## Testing

- `helm lint` passes
- Verified template rendering across 8 scenarios:
  - Default (no autoscaling, no PDB) -- `replicas: 1` present, no HPA/PDB
  - `autoscaling.enabled=true` (Deployment) -- no `replicas` field, HPA targets `Deployment`
  - `autoscaling.enabled=true` + `type=statefulset` -- no `replicas` field, HPA targets `StatefulSet`
  - `podDisruptionBudget.enabled=true` -- PDB with `maxUnavailable: 1`
  - Both enabled -- PDB + HPA + no `replicas` field
  - PDB with `minAvailable=2` -- PDB renders `minAvailable: 2`, no `maxUnavailable`
  - HPA with memory metric + behavior -- both CPU + memory metrics, `behavior` block present
  - StatefulSet + autoscaling + PDB -- all render correctly

## Chart version

Bumped `4.33.1` -> `4.34.0` (new features warrant a minor bump).

Rebased on latest `master` (appVersion `6.9.2`).